### PR TITLE
Kafka-Janitor: Ensure ACLs and api keypair are in place

### DIFF
--- a/clients/dotnet-core-rest/src/Tika.RestClient/Features/ApiKeys/Models/ApiKey.cs
+++ b/clients/dotnet-core-rest/src/Tika.RestClient/Features/ApiKeys/Models/ApiKey.cs
@@ -4,5 +4,7 @@ namespace Tika.RestClient.Features.ApiKeys.Models
     {
         public string Key { get; set; }
         public string Secret { get; set; }
+        public string Description { get; set; }
+        public string Owner { get; set; }
     }
 }

--- a/server/src/server/wrapper/connected/CcloudAccessControlLists.ts
+++ b/server/src/server/wrapper/connected/CcloudAccessControlLists.ts
@@ -7,6 +7,10 @@ export class CcloudAccessControlLists implements AccessControlLists {
         let result = await executeCli(["kafka", "acl", "list", "--cluster", process.env.TIKA_CCLOUD_CLUSTER_ID]);
         let resultObjects = parse(result) as AccessControlList[];
 
+        resultObjects.forEach(elem => {
+            elem.ServiceAccountId = elem.ServiceAccountId.split(':')[1];
+        });
+
         return resultObjects;
     }
 

--- a/server/src/server/wrapper/connected/CcloudAccessControlLists.ts
+++ b/server/src/server/wrapper/connected/CcloudAccessControlLists.ts
@@ -61,7 +61,7 @@ export class CcloudAccessControlLists implements AccessControlLists {
         let command = [
             "kafka", "acl", createOrDelete,
             "--cluster", process.env.TIKA_CCLOUD_CLUSTER_ID,
-            "--service-account-id", serviceAccountId + "",
+            "--service-account", serviceAccountId + "",
             "--operation", operation
         ];
 

--- a/server/src/server/wrapper/connected/CcloudApiKeys.ts
+++ b/server/src/server/wrapper/connected/CcloudApiKeys.ts
@@ -9,7 +9,7 @@ export class CcloudApiKeys implements ApiKeys {
         "api-key",
         "create",
         "--resource", process.env.TIKA_CCLOUD_CLUSTER_ID,
-        "--service-account-id", serviceAccountId + "",
+        "--service-account", serviceAccountId + "",
         "--description", description]
       );
   

--- a/server/src/server/wrapper/connected/CcloudApiKeys.ts
+++ b/server/src/server/wrapper/connected/CcloudApiKeys.ts
@@ -27,7 +27,7 @@ export class CcloudApiKeys implements ApiKeys {
       let cliObjects = parse(cliOutput);
   
       let apiKeys = cliObjects.map(function (obj) {
-        return { Key: obj.Key, Description: obj.Description } as ApiKey
+        return { Key: obj.Key, Description: obj.Description, Owner: obj.Owner } as ApiKey
       });
   
       console.log(apiKeys);

--- a/server/src/server/wrapper/connected/CcloudApiKeys.ts
+++ b/server/src/server/wrapper/connected/CcloudApiKeys.ts
@@ -29,9 +29,7 @@ export class CcloudApiKeys implements ApiKeys {
       let apiKeys = cliObjects.map(function (obj) {
         return { Key: obj.Key, Description: obj.Description, Owner: obj.Owner } as ApiKey
       });
-  
-      console.log(apiKeys);
-  
+    
       return apiKeys;
     }
   

--- a/server/src/server/wrapper/definitions.d.ts
+++ b/server/src/server/wrapper/definitions.d.ts
@@ -12,6 +12,7 @@ type ApiKeySet = {
 type ApiKey = {
     Key: string;
     Description: string;
+    Owner: string;
 }
 
 type AccessControlList = {

--- a/server/src/server/wrapper/notConnected/NotConnectedApiKeys.ts
+++ b/server/src/server/wrapper/notConnected/NotConnectedApiKeys.ts
@@ -20,7 +20,8 @@ export class NotConnectedApiKeys implements ApiKeys {
 
         let apiKey: ApiKey = {
             Key: key,
-            Description: description
+            Description: description,
+            Owner: serviceAccountId.toString()
         };
         this.apiKeys.push(apiKey);
 


### PR DESCRIPTION
- Updated service account id parameter usage to reflect recent changes in ccloud
- ccloud acl list, returns a column 'ServiceAccountId', but the value given isn't a clean value. Instead of an expected id, e.g. '47513', it returns 'User:47513'. I haven't seen any other prefixes(like 'User') yet. Currently handling this by splitting the value with ':', and using the secondary value as the ServiceAccountId.
- Added Owner to ApiKey object

Story details: https://app.clubhouse.io/devex/story/1728