### PR TITLE
Handle inconsistent API response from Confluent if a Service Account already exists

### DIFF
--- a/server/src/server/wrapper/connected/CcloudServiceAccount.ts
+++ b/server/src/server/wrapper/connected/CcloudServiceAccount.ts
@@ -37,7 +37,9 @@ export class CcloudServiceAccount implements ServiceAccounts {
         throw (error);
       }
 
-      if (error.consoleLines.some((l: string): boolean => l.includes("is already in use"))) {
+      // "Error: service name "NAME-HERE" is already in use" is usually returned if the service account exists
+      // "Error: Service Account Not Found: 404 Not Found" can also be returned if the service account exists.. for some reason. Confluent is looking into why but are currently unable to reproduce in a different environment.
+      if (error.consoleLines.some((l: string): boolean => l.includes("is already in use")) || error.consoleLines.some((l: string): boolean => l.includes("404 Not Found"))) {
         let existingServicesAccounts = await this.getServiceAccounts();
 
         let existingServicesAccount = existingServicesAccounts.find(s => s.Name === accountName);

--- a/server/src/server/wrapper/connected/executeCli.ts
+++ b/server/src/server/wrapper/connected/executeCli.ts
@@ -25,7 +25,11 @@ export function executeCli(args: string[]): Promise<string[]> {
         return reject(new CcloudSessionExpiredException());
       }
 
-      reject(new CliException(exitCode, errLines));
+      let combinedLines : any = [];
+      combinedLines = combinedLines.concat(lines);
+      combinedLines = combinedLines.concat(errLines);
+
+      reject(new CliException(exitCode, combinedLines));
     });
   });
 }


### PR DESCRIPTION
A temporary hotfix while we wait for Confluent to fix things.

DEPENDS ON https://github.com/dfds/tika/pull/53 TO BE MERGED. IF NOT MERGED, PIPELINE WILL FAIL 🤷‍♀️ 